### PR TITLE
Zero, One traits have been deprecated in Rust, use Num crate instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ git = "https://github.com/tedsta/gpuarray-rs"
 
 [dependencies]
 rand = "*"
+num = "*"

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
-use std::num::{Zero, One};
+extern crate num;
+use self::num::{Zero, One};
 
 use ga::Array;
 


### PR DESCRIPTION
Reference here: https://github.com/rust-lang/rfcs/pull/369

This should also allow building, running with the latest Rust compiler.